### PR TITLE
fix leave parser selecting wrong player (= instead of ===)

### DIFF
--- a/data/player.js
+++ b/data/player.js
@@ -48,7 +48,7 @@ class Player {
 
         // regexes for matching player state and controller
         const stateRegExp = /BP_PlayerState_C .+?PersistentLevel\.(?<state>BP_PlayerState_C_\d+)\.PlayerName = (?<name>.+)$/;
-        const contollerRegExp = /BP_PlayerState_C .+?PersistentLevel\.(?<state>BP_PlayerState_C_\d+)\.Owner = BP_PlayerController_C'.+?:PersistentLevel.(?<controller>BP_PlayerController_C_\d+)'/;
+        const controllerRegExp = /BP_PlayerState_C .+?PersistentLevel\.(?<state>BP_PlayerState_C_\d+)\.Owner = BP_PlayerController_C'.+?:PersistentLevel.(?<controller>BP_PlayerController_C_\d+)'/;
 
         // wait for this players' state
         const statePromise = brickadia.waitForLine(line => {
@@ -72,7 +72,7 @@ class Player {
 
         // wait for this players' controller
         const controllerPromise = brickadia.waitForLine(line => {
-            const match = line.match(contollerRegExp);
+            const match = line.match(controllerRegExp);
 
             // if no match, return null
             if (!match) return null;

--- a/parsers/leave.js
+++ b/parsers/leave.js
@@ -25,7 +25,7 @@ class LeaveParser extends BaseParser {
         if (!match)
             return null;
 
-        return this._brikkit._players.find(p => p._controller = match[1]);
+        return this._brikkit._players.find(p => p._controller === match[1]);
     }
 }
 


### PR DESCRIPTION
the issue induced a crash that would kill brikkit if a chat message was sent after a second player, named differently than the first, left