### PR TITLE
fix leave parser not running on kick/ban

### DIFF
--- a/parsers/leave.js
+++ b/parsers/leave.js
@@ -17,7 +17,8 @@ class LeaveParser extends BaseParser {
         if (generator !== 'LogNet')
             return null;
 
-        if (!line.startsWith('UNetConnection::Close:'))
+        // this is not "UNetConnection" because the UNetConnection line does not occur on kick/ban
+        if (!line.startsWith('UChannel::Close:'))
             return null;
 
         const ownerRegExp = /Owner: (BP_PlayerController_C_\d+)/;


### PR DESCRIPTION
When a player manually disconnects, there are two similar console logs:

    [2020.06.18-03.35.48:695][116]LogNet: UNetConnection::Close: [UNetConnection] RemoteAddr: <REDACTED>, Name: IpConnection_14, Driver: GameNetDriver IpNetDriver_1, IsServer: YES, PC: BP_PlayerController_C_14, Owner: BP_PlayerController_C_14, UniqueId: INVALID, Channels: 43, Time: 2020.06.18-03.35.48
    [2020.06.18-03.35.48:695][116]LogNet: UChannel::Close: Sending CloseBunch. ChIndex == 0. Name: [UChannel] ChIndex: 0, Closing: 0 [UNetConnection] RemoteAddr: <REDACTED>, Name: IpConnection_14, Driver: GameNetDriver IpNetDriver_1, IsServer: YES, PC: BP_PlayerController_C_14, Owner: BP_PlayerController_C_14, UniqueId: INVALID

However, when a player is kicked or banned only the following of the two is sent:

    [2020.07.24-04.42.00:282][622]LogNet: UChannel::Close: Sending CloseBunch. ChIndex == 0. Name: [UChannel] ChIndex: 0, Closing: 0 [UNetConnection] RemoteAddr: <REDACTED>, Name: IpConnection_2, Driver: GameNetDriver IpNetDriver_0, IsServer: YES, PC: BP_PlayerController_C_2, Owner: BP_PlayerController_C_2, UniqueId: INVALID

Previously the `LeaveParser` depended on lines starting with `UNetConnection::Close:`, which is now replaced with `UChannel::Close:` to better determine which players are on the server.