### PR TITLE
fix leave parser returning undefined instead of null for missing player

### DIFF
--- a/parsers/leave.js
+++ b/parsers/leave.js
@@ -26,7 +26,8 @@ class LeaveParser extends BaseParser {
         if (!match)
             return null;
 
-        return this._brikkit._players.find(p => p._controller === match[1]);
+        const player = this._brikkit._players.find(p => p._controller === match[1]);
+        return player !== undefined ? player : null;
     }
 }
 


### PR DESCRIPTION
if a player was somehow not found by the find function when leaving, `undefined` was sent before. As we all know, `undefined !== null` so `if(leavingPlayer !== null) {` was true even when `leavingPlayer === undefined`. Now `leavingPlayer` cannot be undefined